### PR TITLE
Fix route-suffix-patch Patch

### DIFF
--- a/manifests/registry/overlay_multitenancy/route-suffix-patch.yaml
+++ b/manifests/registry/overlay_multitenancy/route-suffix-patch.yaml
@@ -1,4 +1,3 @@
 - op: replace
-  path: "/spec/to"
-  value: 
-    name: apicurio-registry-mt
+  path: "/spec/to/name"
+  value: apicurio-registry-mt


### PR DESCRIPTION
The `kustomize` template is going to be rejected without this change since it's omitting the `spec.to.kind` field of the Route