### PR TITLE
Fixing KEYCLOAK_URL in Registry deployment

### DIFF
--- a/manifests/registry/base/deployments.yaml
+++ b/manifests/registry/base/deployments.yaml
@@ -38,7 +38,7 @@ spec:
           - name: AUTH_ENABLED
             value: "true"
           - name: KEYCLOAK_URL
-            value: "https://apicurio-sso-rhaf-apicurio-designer.apps.dev-eng-ocp4-mas.dev.3sca.net/auth/"
+            value: "https://apicurio-sso-rhaf-apicurio-designer.apps.dev-eng-ocp4-mas.dev.3sca.net/auth"
           - name: KEYCLOAK_REALM
             value: "apicurio"
           - name: KEYCLOAK_API_CLIENT_ID


### PR DESCRIPTION
fixes this error:

```
2023-07-03 14:49:05 WARN <> [null] (vert.x-eventloop-thread-1) OIDC server is not available at the 'https://apicurio-sso-rhaf-apicurio-designer.apps.dev-eng-ocp4-mas.dev.3sca.net/auth//realms/apicurio' URL. Please make sure it is correct. Note it has to end with a realm value if you work with Keycloak, for example: 'https://localhost:8180/auth/realms/quarkus'
2023-07-03 14:49:05 WARN <> [null] (vert.x-eventloop-thread-1) Tenant 'Default': 'OIDC Server is not available'. OIDC server is not available yet, an attempt to connect will be made duiring the first request. Access to resources protected by this tenant may fail if OIDC server will not become available```

notice the double slash in `'https://apicurio-sso-rhaf-apicurio-designer.apps.dev-eng-ocp4-mas.dev.3sca.net/auth//realms/apicurio`